### PR TITLE
Cakes are always minecraft:cake

### DIFF
--- a/src/main/java/com/oitsjustjose/vtweaks/VTweaks.java
+++ b/src/main/java/com/oitsjustjose/vtweaks/VTweaks.java
@@ -16,6 +16,7 @@ import com.oitsjustjose.vtweaks.event.mobtweaks.MobDropBuffs;
 import com.oitsjustjose.vtweaks.event.mobtweaks.PeacefulSurface;
 import com.oitsjustjose.vtweaks.event.mobtweaks.PetArmory;
 import com.oitsjustjose.vtweaks.event.mobtweaks.SheepDyeFix;
+import com.oitsjustjose.vtweaks.util.CakeRegistry;
 import com.oitsjustjose.vtweaks.util.ConfigParser;
 import com.oitsjustjose.vtweaks.util.GuideNotifier;
 import com.oitsjustjose.vtweaks.util.ModConfig;
@@ -92,5 +93,6 @@ public class VTweaks
     {
         Blocks.COMMAND_BLOCK.setCreativeTab(CreativeTabs.REDSTONE);
         ConfigParser.parseItems();
+        CakeRegistry.init();
     }
 }

--- a/src/main/java/com/oitsjustjose/vtweaks/event/blocktweaks/CakeTweak.java
+++ b/src/main/java/com/oitsjustjose/vtweaks/event/blocktweaks/CakeTweak.java
@@ -1,10 +1,10 @@
 package com.oitsjustjose.vtweaks.event.blocktweaks;
 
+import com.oitsjustjose.vtweaks.util.CakeRegistry;
 import com.oitsjustjose.vtweaks.util.ModConfig;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockCake;
-import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -24,7 +24,7 @@ public class CakeTweak
         if (event.getHarvester() != null && block instanceof BlockCake && block.getMetaFromState(event.getState()) == 0)
         {
             event.getDrops().clear();
-            event.getDrops().add(new ItemStack(Items.CAKE));
+            event.getDrops().add(new ItemStack(CakeRegistry.getItemFromCakeBlock(block)));
         }
     }
 }

--- a/src/main/java/com/oitsjustjose/vtweaks/util/CakeRegistry.java
+++ b/src/main/java/com/oitsjustjose/vtweaks/util/CakeRegistry.java
@@ -1,0 +1,41 @@
+package com.oitsjustjose.vtweaks.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockCake;
+import net.minecraft.item.Item;
+import net.minecraftforge.fml.common.registry.GameRegistry;
+
+public class CakeRegistry
+{
+	private static Map<Block, Item> cakeBlockToItem = new HashMap<Block, Item>();
+
+	@GameRegistry.ObjectHolder("minecraft:cake")
+	public static final Block CAKE_BLOCK = null;
+
+	@GameRegistry.ObjectHolder("minecraft:cake")
+	public static final Item CAKE_ITEM = null;
+
+	public static void init()
+	{
+		cakeBlockToItem.put(CAKE_BLOCK, CAKE_ITEM);
+
+		for (Item item : Item.REGISTRY)
+		{
+			Block block = Block.getBlockFromItem(item);
+			if(block instanceof BlockCake)
+			{
+				cakeBlockToItem.put(block, item);
+			}
+		};
+	}
+
+	public static Item getItemFromCakeBlock(Block block)
+	{
+		Item item = cakeBlockToItem.get(block);
+		if (item == null) item = Item.getItemFromBlock(block);
+		return item;
+	}
+}


### PR DESCRIPTION
There are some cakes added by harvestcraft, and possibly other mods which drop vanilla cakes with the Cake Tweak enabled. I guess this is because there doesn't seem to be an easy way to get cake items from the blocks.

Code mostly borrowed from [AppleCore](https://github.com/squeek502/AppleCore/blob/1.12.2/java/squeek/applecore/api_impl/AppleCoreRegistryImpl.java). There's a [1.14 branch](https://github.com/squeek502/AppleCore/blob/1.14.3/java/squeek/applecore/api_impl/AppleCoreRegistryImpl.java) but I'm not sure if any mods add custom cakes for that yet so I can't test.

https://i.imgur.com/ntGnw17.png
https://i.imgur.com/7GDKJWb.png