### PR TITLE
Create pack.mcmeta

### DIFF
--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+   "pack": {
+      "pack_format": 3,
+      "description": "V-Tweaks resources"
+   }
+}


### PR DESCRIPTION
Without a pack.mcmeta with pack_format set to 3, forge will load mod resources using the LegacyV2Adapter IResourcePack wrapper. This means that lang files will be loaded with the old mixed-case names (e.g. en_US.lang) rather than the new lower-case names (e.g. en_us.lang).